### PR TITLE
#36 Update default.conf.prod

### DIFF
--- a/docker/nginx/conf.d/default.conf.prod
+++ b/docker/nginx/conf.d/default.conf.prod
@@ -11,7 +11,7 @@ server {
     #access_log  /var/log/nginx/host.access.log  main;
 
     location / {
-        root   /var/www/html/static;
+        root   /home/ec2-user/gitrepos/gikenweb/static;
         index  index.html index.htm;
     }
 


### PR DESCRIPTION
## チケットへのリンク
#36 

## やったこと
本番環境へデプロイしやすい形にした。
具体的にいうと、いままでは本番環境（EC2）にて
`git pull`したのち、
`/var/www/html`へ必要な資材をコピーしてデプロイしていた。
これを簡略化し、ミドルウェアの向き先を直接リポジトリに設定することで、
`git pull`のみでデプロイできる形にした。（/var/www/htmlは以降使わない方針。）

## やらないこと
なし

## できるようになること（ユーザ目線）
変化なし

## できなくなること（ユーザ目線）
変化なし

## 動作確認
EC2上で確認済

## その他
なし